### PR TITLE
Remove labels page

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -62,16 +62,6 @@ export class App extends React.Component<any, IAppState> {
                 Classifications
               </Button>
             </Tooltip>
-
-            <Button
-              color="secondary"
-              onClick={this.selectAudio}
-              fullWidth={true}
-              size="small"
-              disabled={true}
-            >
-              Labels
-            </Button>
             <Tooltip title="Export all labels to ~/reverb-export">
               <NotificationContext.Consumer>
                 {({ notify }) => (


### PR DESCRIPTION
- Removed the "Labels" page from the sidebar as labels are now browable from the Classifications page